### PR TITLE
Add sync upstream job

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -1,0 +1,64 @@
+name: Auto sync from upstream
+
+on:
+  schedule:
+    - cron: 0 9 * * 1
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          ref: main
+
+      - name: Set Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream and fetch
+        run: |
+          git remote add upstream https://github.com/eclipse-tractusx/tractus-x-umbrella.git
+          git fetch upstream main
+
+      - name: Checkout to sync branch
+        run: |
+          git checkout -b sync-upstream origin/main
+
+      - name: Merge upstream main
+        run: |
+          set +e
+          git merge upstream/main -m "Merge upstream/main into sync-upstream"
+          MERGE_STATUS=$?
+          if [ $MERGE_STATUS != 0 ]; then
+            echo "Conflicts detected"
+            git add -A 
+            git commit -m "Merge upstream/main into sync-upstream (auto-sync, may contain conflicts)"
+          fi
+          exit 0
+
+      - name: Push sync branch to your fork
+        run: |
+          git push origin sync-upstream --force
+
+      # Config to create PR 
+      - name: Create PR into main
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: main
+          branch: sync-upstream
+          title: Merge sync-upstream to arena2036-x-infre (Conflicts may be present)
+          body: |
+            This PR rebases `main` on top of the latest `upstream/main`.
+          commit-message: "Sync with upstream/main"


### PR DESCRIPTION
Github action to sync from upstream
The action does the following:
- Check out tx-umbrella main
- Add and fetch main
- Checkout to temporary sync branch
- Merge upstream main
- Push sync branch to your fork
- Create PR to main