### PR TITLE
Minor fix

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -5,9 +5,7 @@ on:
     - cron: 0 9 * * 1
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: write-all
 
 jobs:
   sync:


### PR DESCRIPTION
For the sync upstream workflow to work, it needs write permissions enabled in Actions.

**Settings -> Actions -> General:** at bottom write permission and PR permission must be enable for it to work.

