### PR TITLE
chore: rename step to fetch kubeconfig and connect to cluster, add Helm dependency updates

### DIFF
--- a/.github/workflows/deploy-process-arena2036-x-prod.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-prod.yaml
@@ -180,5 +180,4 @@ jobs:
             helm dependency update ./charts/simple-data-backend
             helm dependency update ./charts/tx-data-provider
             helm dependency update ./charts/umbrella
-            helm upgrade --install federated ./charts/umbrella --namespace release25-09 --create-namespace --values charts/umbrella/values-prod.yaml --wait --timeout 10m
-
+            helm upgrade --install federated ./charts/umbrella --namespace release25-09 --create-namespace --values charts/umbrella/values-prod.yaml --debug

--- a/.github/workflows/deploy-process-arena2036-x-prod.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-prod.yaml
@@ -24,10 +24,10 @@
 name: Continuous Deployment Arena-X (prod)
 
 on:
-  # push:
-  #   branches: [ feature/deploy-process-arena2036-x ]
-  # pull_request:
-  #   branches: [ feature/deploy-process-arena2036-x ]
+  push:
+    branches: [ feature/deploy-process-arena2036-x ]
+  pull_request:
+    branches: [ feature/deploy-process-arena2036-x ]
 
   workflow_dispatch:
     inputs:
@@ -47,9 +47,9 @@ on:
         required: false
         type: choice
         options:
-          - install
+          # - install
           - upgrade
-          - uninstall
+          # - uninstall
       helm_values_file:
         description: 'Comma-separated list of Helm values files (relative paths)'
         default: 'charts/umbrella/values-prod.yaml'
@@ -57,7 +57,7 @@ on:
         type: string
       namespace:
         description: 'Namespace to deploy the release'
-        default: 'umbrella'
+        default: 'release25-09'
         required: false
         type: string
       rollback_on_failure:
@@ -89,12 +89,30 @@ jobs:
           sudo mv vault /usr/local/bin/
           vault --version
 
+      #### Prod env. configuration
+      # - name: Fetch kubeconfig from Vault
+      #   run: |
+      #     mkdir -p $HOME/.kube
+      #     export VAULT_ADDR="${{ secrets.VAULT_ADDR_PROD }}"
+      #     export VAULT_TOKEN="${{ secrets.VAULT_TOKEN_PROD }}"
+      #     CLUSTER_PATH="prod/infra/cluster-prod"
+      #     # Fetch kubeconfig
+      #     vault kv get -field=config $CLUSTER_PATH > $HOME/.kube/config
+      #     chmod 600 $HOME/.kube/config
+
+      #     # Extract current context
+      #     CONTEXT=$(yq e '.current-context' $HOME/.kube/config)
+      #     echo "Using context: $CONTEXT"
+
+      #     # Test cluster connection
+      #     kubectl --context=$CONTEXT cluster-info
+
       - name: Fetch kubeconfig from Vault
         run: |
           mkdir -p $HOME/.kube
-          export VAULT_ADDR="${{ secrets.VAULT_ADDR_PROD }}"
-          export VAULT_TOKEN="${{ secrets.VAULT_TOKEN_PROD }}"
-          CLUSTER_PATH="prod/infra/cluster-prod"
+          export VAULT_ADDR="${{ secrets.VAULT_ADDR_STAGING }}"
+          export VAULT_TOKEN="${{ secrets.VAULT_TOKEN_STAGING }}"
+          CLUSTER_PATH="staging/infra/cluster-prod"
           # Fetch kubeconfig
           vault kv get -field=config $CLUSTER_PATH > $HOME/.kube/config
           chmod 600 $HOME/.kube/config

--- a/.github/workflows/deploy-process-arena2036-x-prod.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-prod.yaml
@@ -181,4 +181,4 @@ jobs:
             chmod +x ./helm-dependencies.bash
             ./helm-dependencies.bash
             echo "Running deployment script..."
-            helm upgrade --install federated ./charts/umbrella --namespace release25-09 --create-namespace --values charts/umbrella/values-prod.yaml --debug
+            helm upgrade --install federated ../charts/umbrella --namespace release25-09 --create-namespace --values ../charts/umbrella/values-prod.yaml --debug

--- a/.github/workflows/deploy-process-arena2036-x-prod.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-prod.yaml
@@ -175,10 +175,16 @@ jobs:
           # fi
 
           # Deploy using Helm for testing
+            echo "Current directory:"
             pwd
             ls -la
             
             chmod +x ./helm-dependencies.bash
             ./helm-dependencies.bash
+
+            echo "Building umbrella dependencies..."
+            helm dependency build ../charts/umbrella
+            echo "Dependencies successfully built!"
+                      
             echo "Running deployment script..."
             helm upgrade --install federated ../charts/umbrella --namespace release25-09 --create-namespace --values ../charts/umbrella/values-prod.yaml --debug

--- a/.github/workflows/deploy-process-arena2036-x-prod.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-prod.yaml
@@ -178,8 +178,8 @@ jobs:
 
           # Deploy using Helm for testing
           if [ "$TYPE" = "upgrade" ]; then
-            helm dependency update ./helm
-            helm upgrade --install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
+            helm dependency update ./charts/umbrella
+            helm upgrade --install "$RELEASE_NAME" ./charts/umbrella --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
 
           else
             echo "Unknown deployment_type: ${{ github.event.inputs.deployment_type }}"

--- a/.github/workflows/deploy-process-arena2036-x-prod.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-prod.yaml
@@ -24,10 +24,10 @@
 name: Continuous Deployment Arena-X (prod)
 
 on:
-  push:
-    branches: [ feature/deploy-process-arena2036-x ]
-  pull_request:
-    branches: [ feature/deploy-process-arena2036-x ]
+  # push:
+  #   branches: [ feature/deploy-process-arena2036-x ]
+  # pull_request:
+  #   branches: [ feature/deploy-process-arena2036-x ]
 
   workflow_dispatch:
     inputs:
@@ -47,9 +47,9 @@ on:
         required: false
         type: choice
         options:
-          # - install
+          - install
           - upgrade
-          # - uninstall
+          - uninstall
       helm_values_file:
         description: 'Comma-separated list of Helm values files (relative paths)'
         default: 'charts/umbrella/values-prod.yaml'
@@ -89,30 +89,12 @@ jobs:
           sudo mv vault /usr/local/bin/
           vault --version
 
-      #### Prod env. configuration
-      # - name: Fetch kubeconfig from Vault
-      #   run: |
-      #     mkdir -p $HOME/.kube
-      #     export VAULT_ADDR="${{ secrets.VAULT_ADDR_PROD }}"
-      #     export VAULT_TOKEN="${{ secrets.VAULT_TOKEN_PROD }}"
-      #     CLUSTER_PATH="prod/infra/cluster-prod"
-      #     # Fetch kubeconfig
-      #     vault kv get -field=config $CLUSTER_PATH > $HOME/.kube/config
-      #     chmod 600 $HOME/.kube/config
-
-      #     # Extract current context
-      #     CONTEXT=$(yq e '.current-context' $HOME/.kube/config)
-      #     echo "Using context: $CONTEXT"
-
-      #     # Test cluster connection
-      #     kubectl --context=$CONTEXT cluster-info
-
-      - name: Fetch kubeconfig from Vault
+      - name: Fetch kubeconfig from Vault and connect to cluster
         run: |
           mkdir -p $HOME/.kube
-          export VAULT_ADDR="${{ secrets.VAULT_ADDR_STAGING }}"
-          export VAULT_TOKEN="${{ secrets.VAULT_TOKEN_STAGING }}"
-          CLUSTER_PATH="staging/infra/cluster-prod"
+          export VAULT_ADDR="${{ secrets.VAULT_ADDR_PROD }}"
+          export VAULT_TOKEN="${{ secrets.VAULT_TOKEN_PROD }}"
+          CLUSTER_PATH="prod/infra/cluster-prod"
           # Fetch kubeconfig
           vault kv get -field=config $CLUSTER_PATH > $HOME/.kube/config
           chmod 600 $HOME/.kube/config
@@ -157,34 +139,25 @@ jobs:
             EXTRA_ARGS=""
           fi
 
-          # # Deploy using Helm
-          # if [ "${{ github.event.inputs.deployment_type }}" = "install" ]; then
-          # helm dependency update ./charts/umbrella
-          #   helm install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
-
-          # elif [ "${{ github.event.inputs.deployment_type }}" = "upgrade" ]; then
-          # helm dependency update ./charts/umbrella
-          #   helm upgrade --install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
-
-          # elif [ "${{ github.event.inputs.deployment_type }}" = "uninstall" ]; then
-          #   helm uninstall "$RELEASE_NAME" --namespace "$NAMESPACE"
-
-          # else
-          #   echo "Unknown deployment_type: ${{ github.event.inputs.deployment_type }}"
-          #   exit 1
-          # fi
-
-          # Deploy using Helm for testing
-            echo "Current directory:"
-            pwd
-            ls -la
-            
+          # Run Helm dependencies script
             chmod +x ./helm-dependencies.bash
             ./helm-dependencies.bash
-
+            echo "Running deployment script..."
+            
             echo "Building umbrella dependencies..."
             helm dependency build ../charts/umbrella
             echo "Dependencies successfully built!"
-                      
-            echo "Running deployment script..."
-            helm upgrade --install federated ../charts/umbrella --namespace release25-09 --create-namespace --values ../charts/umbrella/values-prod.yaml --debug
+
+          if [ "${{ github.event.inputs.deployment_type }}" = "install" ]; then
+            helm install "$RELEASE_NAME" ../charts/umbrella --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
+
+          elif [ "${{ github.event.inputs.deployment_type }}" = "upgrade" ]; then
+            helm upgrade --install "$RELEASE_NAME" ../charts/umbrella --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
+
+          elif [ "${{ github.event.inputs.deployment_type }}" = "uninstall" ]; then
+            helm uninstall "$RELEASE_NAME" --namespace "$NAMESPACE"
+
+          else
+            echo "Unknown deployment_type: ${{ github.event.inputs.deployment_type }}"
+            exit 1
+          fi

--- a/.github/workflows/deploy-process-arena2036-x-prod.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-prod.yaml
@@ -142,9 +142,6 @@ jobs:
           TYPE="${{ github.event.inputs.deployment_type }}"
           ROLLBACK="${{ github.event.inputs.rollback_on_failure }}"
 
-          # Default for non-workflow_dispatch triggers for testing
-          TYPE="${TYPE:-upgrade}"
-
           # Build Helm values arguments
           HELM_VALUES_ARGS=""
           IFS=',' read -ra FILE_ARRAY <<< "$VALUE_FILES"
@@ -161,11 +158,11 @@ jobs:
 
           # # Deploy using Helm
           # if [ "${{ github.event.inputs.deployment_type }}" = "install" ]; then
-          #   helm dependency update ./helm
+          # helm dependency update ./charts/umbrella
           #   helm install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
 
           # elif [ "${{ github.event.inputs.deployment_type }}" = "upgrade" ]; then
-          #   helm dependency update ./helm
+          # helm dependency update ./charts/umbrella
           #   helm upgrade --install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
 
           # elif [ "${{ github.event.inputs.deployment_type }}" = "uninstall" ]; then
@@ -177,11 +174,6 @@ jobs:
           # fi
 
           # Deploy using Helm for testing
-          if [ "$TYPE" = "upgrade" ]; then
             helm dependency update ./charts/umbrella
-            helm upgrade --install "$RELEASE_NAME" ./charts/umbrella --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
+            helm upgrade --install federated ./charts/umbrella --namespace release25-09 --create-namespace --values charts/umbrella/values-prod.yaml
 
-          else
-            echo "Unknown deployment_type: ${{ github.event.inputs.deployment_type }}"
-            exit 1
-          fi

--- a/.github/workflows/deploy-process-arena2036-x-prod.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-prod.yaml
@@ -175,6 +175,9 @@ jobs:
           # fi
 
           # Deploy using Helm for testing
+            pwd
+            ls -la
+            
             chmod +x ./helm-dependencies.bash
             ./helm-dependencies.bash
             echo "Running deployment script..."

--- a/.github/workflows/deploy-process-arena2036-x-prod.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-prod.yaml
@@ -156,17 +156,27 @@ jobs:
             EXTRA_ARGS=""
           fi
 
-          # Deploy using Helm
-          if [ "${{ github.event.inputs.deployment_type }}" = "install" ]; then
-            helm dependency update ./helm
-            helm install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
+          # # Deploy using Helm
+          # if [ "${{ github.event.inputs.deployment_type }}" = "install" ]; then
+          #   helm dependency update ./helm
+          #   helm install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
 
-          elif [ "${{ github.event.inputs.deployment_type }}" = "upgrade" ]; then
+          # elif [ "${{ github.event.inputs.deployment_type }}" = "upgrade" ]; then
+          #   helm dependency update ./helm
+          #   helm upgrade --install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
+
+          # elif [ "${{ github.event.inputs.deployment_type }}" = "uninstall" ]; then
+          #   helm uninstall "$RELEASE_NAME" --namespace "$NAMESPACE"
+
+          # else
+          #   echo "Unknown deployment_type: ${{ github.event.inputs.deployment_type }}"
+          #   exit 1
+          # fi
+
+          # Deploy using Helm for testing
+          if [ "${{ github.event.inputs.deployment_type }}" = "upgrade" ]; then
             helm dependency update ./helm
             helm upgrade --install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
-
-          elif [ "${{ github.event.inputs.deployment_type }}" = "uninstall" ]; then
-            helm uninstall "$RELEASE_NAME" --namespace "$NAMESPACE"
 
           else
             echo "Unknown deployment_type: ${{ github.event.inputs.deployment_type }}"

--- a/.github/workflows/deploy-process-arena2036-x-prod.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-prod.yaml
@@ -174,6 +174,11 @@ jobs:
           # fi
 
           # Deploy using Helm for testing
-            helm dependency update ./charts/umbrella
-            helm upgrade --install federated ./charts/umbrella --namespace release25-09 --create-namespace --values charts/umbrella/values-prod.yaml
+            helm dependency update ./dataspace-connector-bundle
+            helm dependency update ./digital-twin-bundle
+            helm dependency update ./identity-and-trust-bundle
+            helm dependency update ./simple-data-backend
+            helm dependency update ./tx-data-provider
+            helm dependency update ./umbrella
+            helm upgrade --install federated ./charts/umbrella --namespace release25-09 --create-namespace --values charts/umbrella/values-prod.yaml --wait --timeout 10m
 

--- a/.github/workflows/deploy-process-arena2036-x-prod.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-prod.yaml
@@ -142,6 +142,9 @@ jobs:
           TYPE="${{ github.event.inputs.deployment_type }}"
           ROLLBACK="${{ github.event.inputs.rollback_on_failure }}"
 
+          # Default for non-workflow_dispatch triggers for testing
+          TYPE="${TYPE:-upgrade}"
+
           # Build Helm values arguments
           HELM_VALUES_ARGS=""
           IFS=',' read -ra FILE_ARRAY <<< "$VALUE_FILES"
@@ -174,7 +177,7 @@ jobs:
           # fi
 
           # Deploy using Helm for testing
-          if [ "${{ github.event.inputs.deployment_type }}" = "upgrade" ]; then
+          if [ "$TYPE" = "upgrade" ]; then
             helm dependency update ./helm
             helm upgrade --install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
 

--- a/.github/workflows/deploy-process-arena2036-x-prod.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-prod.yaml
@@ -174,11 +174,11 @@ jobs:
           # fi
 
           # Deploy using Helm for testing
-            helm dependency update ./dataspace-connector-bundle
-            helm dependency update ./digital-twin-bundle
-            helm dependency update ./identity-and-trust-bundle
-            helm dependency update ./simple-data-backend
-            helm dependency update ./tx-data-provider
-            helm dependency update ./umbrella
+            helm dependency update ./charts/data-persistence-layer-bundle
+            helm dependency update ./charts/digital-twin-bundle
+            helm dependency update ./charts/identity-and-trust-bundle
+            helm dependency update ./charts/simple-data-backend
+            helm dependency update ./charts/tx-data-provider
+            helm dependency update ./charts/umbrella
             helm upgrade --install federated ./charts/umbrella --namespace release25-09 --create-namespace --values charts/umbrella/values-prod.yaml --wait --timeout 10m
 

--- a/.github/workflows/deploy-process-arena2036-x-prod.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-prod.yaml
@@ -24,10 +24,10 @@
 name: Continuous Deployment Arena-X (prod)
 
 on:
-  push:
-    branches: [ feature/deploy-process-arena2036-x ]
-  pull_request:
-    branches: [ feature/deploy-process-arena2036-x ]
+  # push:
+  #   branches: [ feature/deploy-process-arena2036-x ]
+  # pull_request:
+  #   branches: [ feature/deploy-process-arena2036-x ]
 
   workflow_dispatch:
     inputs:
@@ -47,9 +47,9 @@ on:
         required: false
         type: choice
         options:
-          # - install
+          - install
           - upgrade
-          # - uninstall
+          - uninstall
       helm_values_file:
         description: 'Comma-separated list of Helm values files (relative paths)'
         default: 'charts/umbrella/values-prod.yaml'
@@ -57,7 +57,7 @@ on:
         type: string
       namespace:
         description: 'Namespace to deploy the release'
-        default: 'release25-09'
+        default: 'umbrella'
         required: false
         type: string
       rollback_on_failure:
@@ -89,30 +89,12 @@ jobs:
           sudo mv vault /usr/local/bin/
           vault --version
 
-      #### Prod env. configuration
-      # - name: Fetch kubeconfig from Vault
-      #   run: |
-      #     mkdir -p $HOME/.kube
-      #     export VAULT_ADDR="${{ secrets.VAULT_ADDR_PROD }}"
-      #     export VAULT_TOKEN="${{ secrets.VAULT_TOKEN_PROD }}"
-      #     CLUSTER_PATH="prod/infra/cluster-prod"
-      #     # Fetch kubeconfig
-      #     vault kv get -field=config $CLUSTER_PATH > $HOME/.kube/config
-      #     chmod 600 $HOME/.kube/config
-
-      #     # Extract current context
-      #     CONTEXT=$(yq e '.current-context' $HOME/.kube/config)
-      #     echo "Using context: $CONTEXT"
-
-      #     # Test cluster connection
-      #     kubectl --context=$CONTEXT cluster-info
-
       - name: Fetch kubeconfig from Vault
         run: |
           mkdir -p $HOME/.kube
-          export VAULT_ADDR="${{ secrets.VAULT_ADDR_STAGING }}"
-          export VAULT_TOKEN="${{ secrets.VAULT_TOKEN_STAGING }}"
-          CLUSTER_PATH="staging/infra/cluster-prod"
+          export VAULT_ADDR="${{ secrets.VAULT_ADDR_PROD }}"
+          export VAULT_TOKEN="${{ secrets.VAULT_TOKEN_PROD }}"
+          CLUSTER_PATH="prod/infra/cluster-prod"
           # Fetch kubeconfig
           vault kv get -field=config $CLUSTER_PATH > $HOME/.kube/config
           chmod 600 $HOME/.kube/config
@@ -156,28 +138,19 @@ jobs:
             EXTRA_ARGS=""
           fi
 
-          # # Deploy using Helm
-          # if [ "${{ github.event.inputs.deployment_type }}" = "install" ]; then
-          # helm dependency update ./charts/umbrella
-          #   helm install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
+          # Deploy using Helm
+          if [ "${{ github.event.inputs.deployment_type }}" = "install" ]; then
+            helm dependency update ./helm
+            helm install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
 
-          # elif [ "${{ github.event.inputs.deployment_type }}" = "upgrade" ]; then
-          # helm dependency update ./charts/umbrella
-          #   helm upgrade --install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
+          elif [ "${{ github.event.inputs.deployment_type }}" = "upgrade" ]; then
+            helm dependency update ./helm
+            helm upgrade --install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
 
-          # elif [ "${{ github.event.inputs.deployment_type }}" = "uninstall" ]; then
-          #   helm uninstall "$RELEASE_NAME" --namespace "$NAMESPACE"
+          elif [ "${{ github.event.inputs.deployment_type }}" = "uninstall" ]; then
+            helm uninstall "$RELEASE_NAME" --namespace "$NAMESPACE"
 
-          # else
-          #   echo "Unknown deployment_type: ${{ github.event.inputs.deployment_type }}"
-          #   exit 1
-          # fi
-
-          # Deploy using Helm for testing
-            helm dependency update ./charts/data-persistence-layer-bundle
-            helm dependency update ./charts/digital-twin-bundle
-            helm dependency update ./charts/identity-and-trust-bundle
-            helm dependency update ./charts/simple-data-backend
-            helm dependency update ./charts/tx-data-provider
-            helm dependency update ./charts/umbrella
-            helm upgrade --install federated ./charts/umbrella --namespace release25-09 --create-namespace --values charts/umbrella/values-prod.yaml --debug
+          else
+            echo "Unknown deployment_type: ${{ github.event.inputs.deployment_type }}"
+            exit 1
+          fi

--- a/.github/workflows/deploy-process-arena2036-x-prod.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-prod.yaml
@@ -24,10 +24,10 @@
 name: Continuous Deployment Arena-X (prod)
 
 on:
-  # push:
-  #   branches: [ feature/deploy-process-arena2036-x ]
-  # pull_request:
-  #   branches: [ feature/deploy-process-arena2036-x ]
+  push:
+    branches: [ feature/deploy-process-arena2036-x ]
+  pull_request:
+    branches: [ feature/deploy-process-arena2036-x ]
 
   workflow_dispatch:
     inputs:
@@ -47,9 +47,9 @@ on:
         required: false
         type: choice
         options:
-          - install
+          # - install
           - upgrade
-          - uninstall
+          # - uninstall
       helm_values_file:
         description: 'Comma-separated list of Helm values files (relative paths)'
         default: 'charts/umbrella/values-prod.yaml'
@@ -57,7 +57,7 @@ on:
         type: string
       namespace:
         description: 'Namespace to deploy the release'
-        default: 'umbrella'
+        default: 'release25-09'
         required: false
         type: string
       rollback_on_failure:
@@ -89,12 +89,30 @@ jobs:
           sudo mv vault /usr/local/bin/
           vault --version
 
+      #### Prod env. configuration
+      # - name: Fetch kubeconfig from Vault
+      #   run: |
+      #     mkdir -p $HOME/.kube
+      #     export VAULT_ADDR="${{ secrets.VAULT_ADDR_PROD }}"
+      #     export VAULT_TOKEN="${{ secrets.VAULT_TOKEN_PROD }}"
+      #     CLUSTER_PATH="prod/infra/cluster-prod"
+      #     # Fetch kubeconfig
+      #     vault kv get -field=config $CLUSTER_PATH > $HOME/.kube/config
+      #     chmod 600 $HOME/.kube/config
+
+      #     # Extract current context
+      #     CONTEXT=$(yq e '.current-context' $HOME/.kube/config)
+      #     echo "Using context: $CONTEXT"
+
+      #     # Test cluster connection
+      #     kubectl --context=$CONTEXT cluster-info
+
       - name: Fetch kubeconfig from Vault
         run: |
           mkdir -p $HOME/.kube
-          export VAULT_ADDR="${{ secrets.VAULT_ADDR_PROD }}"
-          export VAULT_TOKEN="${{ secrets.VAULT_TOKEN_PROD }}"
-          CLUSTER_PATH="prod/infra/cluster-prod"
+          export VAULT_ADDR="${{ secrets.VAULT_ADDR_STAGING }}"
+          export VAULT_TOKEN="${{ secrets.VAULT_TOKEN_STAGING }}"
+          CLUSTER_PATH="staging/infra/cluster-prod"
           # Fetch kubeconfig
           vault kv get -field=config $CLUSTER_PATH > $HOME/.kube/config
           chmod 600 $HOME/.kube/config
@@ -117,6 +135,7 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy Release
+        working-directory: hack/
         run: |
           NAMESPACE="${{ github.event.inputs.namespace }}"
           RELEASE_NAME="${{ github.event.inputs.deployment_name }}"
@@ -138,19 +157,25 @@ jobs:
             EXTRA_ARGS=""
           fi
 
-          # Deploy using Helm
-          if [ "${{ github.event.inputs.deployment_type }}" = "install" ]; then
-            helm dependency update ./helm
-            helm install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
+          # # Deploy using Helm
+          # if [ "${{ github.event.inputs.deployment_type }}" = "install" ]; then
+          # helm dependency update ./charts/umbrella
+          #   helm install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
 
-          elif [ "${{ github.event.inputs.deployment_type }}" = "upgrade" ]; then
-            helm dependency update ./helm
-            helm upgrade --install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
+          # elif [ "${{ github.event.inputs.deployment_type }}" = "upgrade" ]; then
+          # helm dependency update ./charts/umbrella
+          #   helm upgrade --install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
 
-          elif [ "${{ github.event.inputs.deployment_type }}" = "uninstall" ]; then
-            helm uninstall "$RELEASE_NAME" --namespace "$NAMESPACE"
+          # elif [ "${{ github.event.inputs.deployment_type }}" = "uninstall" ]; then
+          #   helm uninstall "$RELEASE_NAME" --namespace "$NAMESPACE"
 
-          else
-            echo "Unknown deployment_type: ${{ github.event.inputs.deployment_type }}"
-            exit 1
-          fi
+          # else
+          #   echo "Unknown deployment_type: ${{ github.event.inputs.deployment_type }}"
+          #   exit 1
+          # fi
+
+          # Deploy using Helm for testing
+            chmod +x ./helm-dependencies.bash
+            ./helm-dependencies.bash
+            echo "Running deployment script..."
+            helm upgrade --install federated ./charts/umbrella --namespace release25-09 --create-namespace --values charts/umbrella/values-prod.yaml --debug

--- a/.github/workflows/deploy-process-arena2036-x-staging.yaml
+++ b/.github/workflows/deploy-process-arena2036-x-staging.yaml
@@ -57,7 +57,7 @@ on:
         type: string
       namespace:
         description: 'Namespace to deploy the release'
-        default: 'umbrella'
+        default: 'release25-09'
         required: false
         type: string
       rollback_on_failure:
@@ -89,7 +89,7 @@ jobs:
           sudo mv vault /usr/local/bin/
           vault --version
 
-      - name: Fetch kubeconfig from Vault
+      - name: Fetch kubeconfig from Vault and connect to cluster
         run: |
           mkdir -p $HOME/.kube
           export VAULT_ADDR="${{ secrets.VAULT_ADDR_STAGING }}"
@@ -117,6 +117,7 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy Release
+        working-directory: hack/
         run: |
           NAMESPACE="${{ github.event.inputs.namespace }}"
           RELEASE_NAME="${{ github.event.inputs.deployment_name }}"
@@ -138,14 +139,20 @@ jobs:
             EXTRA_ARGS=""
           fi
 
-          # Deploy using Helm
+          # Run Helm dependencies script
+            chmod +x ./helm-dependencies.bash
+            ./helm-dependencies.bash
+            echo "Running deployment script..."
+            
+            echo "Building umbrella dependencies..."
+            helm dependency build ../charts/umbrella
+            echo "Dependencies successfully built!"
+
           if [ "${{ github.event.inputs.deployment_type }}" = "install" ]; then
-            helm dependency update ./helm
-            helm install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
+            helm install "$RELEASE_NAME" ../charts/umbrella --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
 
           elif [ "${{ github.event.inputs.deployment_type }}" = "upgrade" ]; then
-            helm dependency update ./helm
-            helm upgrade --install "$RELEASE_NAME" ./helm --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
+            helm upgrade --install "$RELEASE_NAME" ../charts/umbrella --namespace "$NAMESPACE" --create-namespace $HELM_VALUES_ARGS $EXTRA_ARGS
 
           elif [ "${{ github.event.inputs.deployment_type }}" = "uninstall" ]; then
             helm uninstall "$RELEASE_NAME" --namespace "$NAMESPACE"

--- a/hack/helm-dependencies.bash
+++ b/hack/helm-dependencies.bash
@@ -62,7 +62,7 @@ else
   fi
 fi
 
-CHARTS_DIR="./charts"
+CHARTS_DIR="../charts"
 TX_DATA_PROVIDER_DIR="$CHARTS_DIR/tx-data-provider"
 UMBRELLA_DIR="$CHARTS_DIR/umbrella"
 


### PR DESCRIPTION
**Description:**

- Renamed step to "Fetch kubeconfig from Vault and connect to cluster".
- Added Helm dependency update and build for umbrella and related charts.
- Updated hack/helm-dependencies.bash to correct CHARTS_DIR path from ./charts → ../charts.
- 
**Testing:**
- Deployment tested on production with hardcoded values – working fine.
- Required further testing after merging code into main branch using workflow_dispatch option.